### PR TITLE
Debezium update

### DIFF
--- a/connectors/debezium-mongodb-source/2.5.1/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/2.5.1/debezium-mongodb-source.md
@@ -142,6 +142,17 @@ This example shows how to change the data of a MongoDB table using the Pulsar De
         --namespace default \
         --source-config '{"mongodb.hosts": "rs0/mongodb:27017","mongodb.name": "dbserver1","mongodb.user": "debezium","mongodb.password": "dbz","mongodb.task.id": "1","database.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
         ```
+
+        > **Note**
+        > 
+        > Currently, the destination topic (specified by the `destination-topic-name` option ) is a required configuration but it is not used for the Debezium connector to save data. The Debezium connector saves data on the following 4 types of topics:
+        > 
+        > - One topic for storing the database metadata messages. It is named with the database server name ( `database.server.name`), like `public/default/database.server.name`.
+        > - One topic (`database.history.pulsar.topic`) for storing the database history information. The connector writes and recovers DDL statements on this topic.
+        > - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
+        > - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
+        >
+        > If automatic topic creation is disabled on the Pulsar broker, you need to manually create these 4 types of topics and the destination topic.
    
    * Use the **YAML** configuration file as shown previously.
       

--- a/connectors/debezium-mysql-source/2.5.1/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.5.1/debezium-mysql.md
@@ -158,6 +158,17 @@ This example shows how to change the data of a MySQL table using the Pulsar Debe
         --source-config '{"database.hostname": "localhost","database.port": "3306","database.user": "debezium","database.password": "dbz","database.server.id": "184054","database.server.name": "dbserver1","database.whitelist": "inventory","database.history": "org.apache.pulsar.io.debezium.PulsarDatabaseHistory","database.history.pulsar.topic": "history-topic","database.history.pulsar.service.url": "pulsar://127.0.0.1:6650","key.converter": "org.apache.kafka.connect.json.JsonConverter","value.converter": "org.apache.kafka.connect.json.JsonConverter","pulsar.service.url": "pulsar://127.0.0.1:6650","offset.storage.topic": "offset-topic"}'
         ```
 
+        > **Note**
+        > 
+        > Currently, the destination topic (specified by the `destination-topic-name` option ) is a required configuration but it is not used for the Debezium connector to save data. The Debezium connector saves data on the following 4 types of topics:
+        > 
+        > - One topic for storing the database metadata messages. It is named with the database server name ( `database.server.name`), like `public/default/database.server.name`.
+        > - One topic (`database.history.pulsar.topic`) for storing the database history information. The connector writes and recovers DDL statements on this topic.
+        > - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
+        > - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
+        >
+        > If automatic topic creation is disabled on the Pulsar broker, you need to manually create these 4 types of topics and the destination topic.
+
     * Use the **YAML** configuration file as shown previously.
   
         ```bash

--- a/connectors/debezium-postgres-source/2.5.1/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.5.1/debezium-postgres-source.md
@@ -139,6 +139,17 @@ This example shows how to change the data of a PostgreSQL table using the Pulsar
         --namespace default \
         --source-config '{"database.hostname": "localhost","database.port": "5432","database.user": "postgres","database.password": "postgres","database.dbname": "postgres","database.server.name": "dbserver1","schema.whitelist": "inventory","pulsar.service.url": "pulsar://127.0.0.1:6650"}'
         ```
+
+        > **Note**
+        > 
+        > Currently, the destination topic (specified by the `destination-topic-name` option ) is a required configuration but it is not used for the Debezium connector to save data. The Debezium connector saves data on the following 4 types of topics:
+        > 
+        > - One topic for storing the database metadata messages. It is named with the database server name ( `database.server.name`), like `public/default/database.server.name`.
+        > - One topic (`database.history.pulsar.topic`) for storing the database history information. The connector writes and recovers DDL statements on this topic.
+        > - One topic (`offset.storage.topic`) for storing the offset metadata messages. The connector saves the last successfully-committed offsets on this topic.
+        > - One per-table topic. The connector writes change events for all operations that occur in a table to a single Pulsar topic that is specific to that table.
+        >
+        > If automatic topic creation is disabled on the Pulsar broker, you need to manually create these 4 types of topics and the destination topic.
    
    * Use the **YAML** configuration file as shown previously.
       


### PR DESCRIPTION
### Motivation
The Debezium source connectors (including the MongoDB, MySQL and PostgreSQL) do not use the output topic for saving data. Instead, the connector will create its own topic for publishing purposes. Therefore, update the doc accordingly.

### Modifications
Update Debezium source connector docs
Affected releases: 2.5.1

### Documentation
The preview link looks good:
https://staging--streamnative-hub.netlify.app/connectors/debezium-mongodb-source/2.5.1#usage