### PR TITLE
Update filesystem offloader config

### DIFF
--- a/offloaders/filesystem/2.5.1/filesystem.md
+++ b/offloaders/filesystem/2.5.1/filesystem.md
@@ -141,7 +141,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `fileSystemURI` | Connection address, which is the URI to access the default Hadoop distributed file system. | hdfs://127.0.0.1:9000
     `offloadersDirectory` | Offloader directory | offloaders
-    `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | ../conf/filesystem_offload_core_site.xml
+    `fileSystemProfilePath` | Hadoop profile path. The configuration file is stored in the Hadoop profile path. It contains various settings for Hadoop performance tuning. | conf/filesystem_offload_core_site.xml
 
     @@@
 
@@ -151,7 +151,7 @@ You can configure the filesystem offloader driver in the `broker.conf` or `stand
     |---|---|---
     `managedLedgerOffloadDriver` | Offloader driver name, which is case-insensitive. | filesystem
     `offloadersDirectory` | Offloader directory | offloaders
-    `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | ../conf/filesystem_offload_core_site.xml
+    `fileSystemProfilePath` | NFS profile path. The configuration file is stored in the NFS profile path. It contains various settings for performance tuning. | conf/filesystem_offload_core_site.xml
 
     @@@
 
@@ -356,7 +356,7 @@ Set the following configurations in the `conf/standalone.conf` file.
 ```conf
 managedLedgerOffloadDriver=filesystem
 fileSystemURI=hdfs://127.0.0.1:9000
-fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+fileSystemProfilePath=conf/filesystem_offload_core_site.xml
 ```
 
 > **Note**
@@ -398,7 +398,7 @@ As indicated in the [configuration](#configuration) section, you need to configu
 
     ```conf
     managedLedgerOffloadDriver=filesystem
-    fileSystemProfilePath=../conf/filesystem_offload_core_site.xml
+    fileSystemProfilePath=conf/filesystem_offload_core_site.xml
     ```
 
 2. Modify the *filesystem_offload_core_site.xml* as follows.


### PR DESCRIPTION
### Motivation

For File System Storage, `fileSystemProfilePath` is the file system profile path; when we use a relative path, the current dir is the pulsar root dir, not `conf/` dir, so the correct relative path is `conf/filesystem_offload_core_site.xml` not `../conf/filesystem_offload_core_site.xml`.

### Doc preview link
https://staging--streamnative-hub.netlify.app/offloaders/filesystem/2.5.1
