### PR TITLE
Fix tag filtering

### DIFF
--- a/connectors/debezium-mongodb-source/2.5.0/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/2.5.0/debezium-mongodb-source.md
@@ -1,5 +1,5 @@
 ---
-description: The Debezium MongoDB source connector pulls messages from MongDB and persists the messages to Pulsar topics
+description: The Debezium MongoDB source connector pulls messages from MongoDB and persists the messages to Pulsar topics
 author: ["ASF"]
 contributors: ["ASF"]
 language: Java
@@ -21,7 +21,7 @@ dockerfile:
 id: "debezium-mongodb-source"
 ---
 
-The Debezium source connector pulls messages from MongDB and persists the messages to Pulsar topics.
+The Debezium source connector pulls messages from MongoDB and persists the messages to Pulsar topics.
 
 # Configuration 
 

--- a/connectors/debezium-mongodb-source/2.5.1/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/2.5.1/debezium-mongodb-source.md
@@ -1,5 +1,5 @@
 ---
-description: The Debezium MongoDB source connector pulls messages from MongDB and persists the messages to Pulsar topics
+description: The Debezium MongoDB source connector pulls messages from MongoDB and persists the messages to Pulsar topics
 author: ["ASF"]
 contributors: ["ASF"]
 language: Java
@@ -21,7 +21,7 @@ dockerfile:
 id: "debezium-mongodb-source"
 ---
 
-The Debezium source connector pulls messages from MongDB and persists the messages to Pulsar topics.
+The Debezium source connector pulls messages from MongoDB and persists the messages to Pulsar topics.
 
 # Configuration 
 

--- a/connectors/debezium-mysql-source/2.4.0/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.4.0/debezium-mysql.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.0/pulsar-io/debezium/mysql"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "MySQL"]
+tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-mysql-source/2.4.1/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.4.1/debezium-mysql.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.1/pulsar-io/debezium/mysql"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "MySQL"]
+tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-mysql-source/2.4.2/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.4.2/debezium-mysql.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.2/pulsar-io/debezium/mysql"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "MySQL"]
+tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-mysql-source/2.5.0/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.5.0/debezium-mysql.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.5.0/pulsar-io/debezium/mysql"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "MySQL"]
+tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-mysql-source/2.5.1/debezium-mysql.md
+++ b/connectors/debezium-mysql-source/2.5.1/debezium-mysql.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.5.1/pulsar-io/debezium/mysql"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "MySQL"]
+tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-postgres-source/2.4.0/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.4.0/debezium-postgres-source.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.0/pulsar-io/debezium/postgres"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres"]
+tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-postgres-source/2.4.1/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.4.1/debezium-postgres-source.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.1/pulsar-io/debezium/postgres"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres"]
+tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-postgres-source/2.4.2/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.4.2/debezium-postgres-source.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.4.2/pulsar-io/debezium/postgres"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres"]
+tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-postgres-source/2.5.0/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.5.0/debezium-postgres-source.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.5.0/pulsar-io/debezium/postgres"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres"]
+tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/connectors/debezium-postgres-source/2.5.1/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/2.5.1/debezium-postgres-source.md
@@ -6,7 +6,7 @@ language: Java
 document: 
 source: "https://github.com/apache/pulsar/tree/v2.5.1/pulsar-io/debezium/postgres"
 license: Apache License 2.0
-tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres"]
+tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"


### PR DESCRIPTION
When navigating to the Pulsar hub, initially, all the connectors are listed. When clicking on Sources or Sinks, the list is filtered down, but some connectors get lost when filtering. 
This PR fixes these by adding the missing 'Source' tag to their respective files.