### PR TITLE
Add code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 *                       @streamnative/technical-writers
 *                       @RobertIndie
 *                       @shibd
+*                       @streamnative/product
+*                       @nlu90

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 *                       @streamnative/technical-writers
+*                       @RobertIndie
+*                       @shibd


### PR DESCRIPTION
Currently, there are no members in the team technical-writers, so it's not convenient to merge PR in the pulsar-hub repo.

Add code owner: @RobertIndie @shibd 