### PR TITLE
Delete *.yaml for manually doc connectors

### DIFF
--- a/connectors/canal-source/canal-source.yaml
+++ b/connectors/canal-source/canal-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/canal-logo.png"

--- a/connectors/canal-source/v2.10.5/canal-source.md
+++ b/connectors/canal-source/v2.10.5/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-canal-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/canal-source/v2.11.4/canal-source.md
+++ b/connectors/canal-source/v2.11.4/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-canal-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/canal-source/v3.0.6/canal-source.md
+++ b/connectors/canal-source/v3.0.6/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-canal-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/canal-source/v3.1.2/canal-source.md
+++ b/connectors/canal-source/v3.1.2/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-canal-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/canal-source/v3.2.3/canal-source.md
+++ b/connectors/canal-source/v3.2.3/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-canal-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/canal-source/v3.3.1/canal-source.md
+++ b/connectors/canal-source/v3.3.1/canal-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Canal", "Source", "MySQL"]
 alias: Canal Source
 features: ["Use Canal source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/canal-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-canal-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/cassandra-sink.yaml
+++ b/connectors/cassandra-sink/cassandra-sink.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/cassandra-sink.png"

--- a/connectors/cassandra-sink/v2.10.5/cassandra-sink.md
+++ b/connectors/cassandra-sink/v2.10.5/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-cassandra-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/v2.11.4/cassandra-sink.md
+++ b/connectors/cassandra-sink/v2.11.4/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-cassandra-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/v3.0.6/cassandra-sink.md
+++ b/connectors/cassandra-sink/v3.0.6/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-cassandra-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/v3.1.2/cassandra-sink.md
+++ b/connectors/cassandra-sink/v3.1.2/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-cassandra-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/v3.2.3/cassandra-sink.md
+++ b/connectors/cassandra-sink/v3.2.3/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-cassandra-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/cassandra-sink/v3.3.1/cassandra-sink.md
+++ b/connectors/cassandra-sink/v3.3.1/cassandra-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Cassandra", "Sink"]
 alias: Cassandra Sink
 features: ["Use Cassandra sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/cassandra-sink.jpg"
+icon: "/images/connectors/cassandra-sink.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-cassandra-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/debezium-mongodb-source.yaml
+++ b/connectors/debezium-mongodb-source/debezium-mongodb-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/debezium.png"

--- a/connectors/debezium-mongodb-source/v2.10.5/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v2.10.5/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-debezium-mongodb-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/v2.11.4/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v2.11.4/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-debezium-mongodb-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/v3.0.6/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v3.0.6/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-debezium-mongodb-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/v3.1.2/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v3.1.2/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-debezium-mongodb-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/v3.2.3/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v3.2.3/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-debezium-mongodb-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mongodb-source/v3.3.1/debezium-mongodb-source.md
+++ b/connectors/debezium-mongodb-source/v3.3.1/debezium-mongodb-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium MongoDB Source
 features: ["Use Debezium MongoDB source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-debezium-mongodb-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/debezium-mssql-source.yaml
+++ b/connectors/debezium-mssql-source/debezium-mssql-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/debezium.png"

--- a/connectors/debezium-mssql-source/v2.10.5/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v2.10.5/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-debezium-mssql-2.10.5.15.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/v2.11.4/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v2.11.4/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-debezium-mssql-2.11.4.3.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/v3.0.6/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v3.0.6/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-debezium-mssql-3.0.6.1.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/v3.1.2/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v3.1.2/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-debezium-mssql-3.1.2.3.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/v3.2.3/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v3.2.3/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-debezium-mssql-3.2.3.2.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mssql-source/v3.3.1/debezium-mssql-source.md
+++ b/connectors/debezium-mssql-source/v3.3.1/debezium-mssql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "Source"]
 alias: Debezium Microsoft SQL Server Source
 features: ["Use Debezium Microsoft SQL Server source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-debezium-mssql-3.3.1.2.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/debezium-mysql-source.yaml
+++ b/connectors/debezium-mysql-source/debezium-mysql-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/debezium.png"

--- a/connectors/debezium-mysql-source/v2.10.5/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v2.10.5/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-debezium-mysql-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/v2.11.4/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v2.11.4/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-debezium-mysql-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/v3.0.6/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v3.0.6/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-debezium-mysql-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/v3.1.2/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v3.1.2/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-debezium-mysql-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/v3.2.3/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v3.2.3/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-debezium-mysql-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-mysql-source/v3.3.1/debezium-mysql-source.md
+++ b/connectors/debezium-mysql-source/v3.3.1/debezium-mysql-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "MySQL", "Source"]
 alias: Debezium MySQL Source
 features: ["Use Debezium MySQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-debezium-mysql-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/debezium-postgres-source.yaml
+++ b/connectors/debezium-postgres-source/debezium-postgres-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/debezium.png"

--- a/connectors/debezium-postgres-source/v2.10.5/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v2.10.5/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-debezium-postgres-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/v2.11.4/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v2.11.4/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-debezium-postgres-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/v3.0.6/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v3.0.6/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-debezium-postgres-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/v3.1.2/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v3.1.2/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-debezium-postgres-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/v3.2.3/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v3.2.3/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-debezium-postgres-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/debezium-postgres-source/v3.3.1/debezium-postgres-source.md
+++ b/connectors/debezium-postgres-source/v3.3.1/debezium-postgres-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Debezium", "PostgreSQL", "Postgres", "Source"]
 alias: Debezium PostgreSQL Source
 features: ["Use Debezium PostgreSQL source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/debezium.jpg"
+icon: "/images/connectors/debezium.png"
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-debezium-postgres-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/file-source/file-source.yaml
+++ b/connectors/file-source/file-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/apache-logo.png"

--- a/connectors/file-source/v2.10.5/file-source.md
+++ b/connectors/file-source/v2.10.5/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-file-2.10.5.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/file-source/v2.11.4/file-source.md
+++ b/connectors/file-source/v2.11.4/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-file-2.11.4.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/file-source/v3.0.6/file-source.md
+++ b/connectors/file-source/v3.0.6/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-file-3.0.6.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/file-source/v3.1.2/file-source.md
+++ b/connectors/file-source/v3.1.2/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-file-3.1.2.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/file-source/v3.2.3/file-source.md
+++ b/connectors/file-source/v3.2.3/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-file-3.2.3.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/file-source/v3.3.1/file-source.md
+++ b/connectors/file-source/v3.3.1/file-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "File", "Source"]
 alias: File Source
 features: ["Use File source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/apache-logo.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-file-3.3.1.nar"
 support: Apache community
 support_link: https://streamnative.io

--- a/connectors/flume-sink/flume-sink.yaml
+++ b/connectors/flume-sink/flume-sink.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/flume.png"

--- a/connectors/flume-sink/v2.10.5/flume-sink.md
+++ b/connectors/flume-sink/v2.10.5/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-flume-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-sink/v2.11.4/flume-sink.md
+++ b/connectors/flume-sink/v2.11.4/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-flume-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-sink/v3.0.6/flume-sink.md
+++ b/connectors/flume-sink/v3.0.6/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-flume-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-sink/v3.1.2/flume-sink.md
+++ b/connectors/flume-sink/v3.1.2/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-flume-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-sink/v3.2.3/flume-sink.md
+++ b/connectors/flume-sink/v3.2.3/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-flume-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-sink/v3.3.1/flume-sink.md
+++ b/connectors/flume-sink/v3.3.1/flume-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Sink"]
 alias: Flume Sink
 features: ["Use Flume sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-flume-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/flume-source.yaml
+++ b/connectors/flume-source/flume-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/flume.png"

--- a/connectors/flume-source/v2.10.5/flume-source.md
+++ b/connectors/flume-source/v2.10.5/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-flume-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/v2.11.4/flume-source.md
+++ b/connectors/flume-source/v2.11.4/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-flume-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/v3.0.6/flume-source.md
+++ b/connectors/flume-source/v3.0.6/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-flume-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/v3.1.2/flume-source.md
+++ b/connectors/flume-source/v3.1.2/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-flume-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/v3.2.3/flume-source.md
+++ b/connectors/flume-source/v3.2.3/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-flume-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/flume-source/v3.3.1/flume-source.md
+++ b/connectors/flume-source/v3.3.1/flume-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Flume", "Source"]
 alias: Flume Source
 features: ["Use Flume source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/flume.jpg"
+icon: "/images/connectors/flume.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-flume-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-clickhouse-sink/jdbc-clickhouse-sink.yaml
+++ b/connectors/jdbc-clickhouse-sink/jdbc-clickhouse-sink.yaml
@@ -1,1 +1,0 @@
-icon: /images/connectors/apache-logo.png

--- a/connectors/jdbc-clickhouse-sink/v3.0.6/jdbc-clickhouse-sink.md
+++ b/connectors/jdbc-clickhouse-sink/v3.0.6/jdbc-clickhouse-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC clickhouse Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-jdbc-clickhouse-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-clickhouse-sink/v3.1.2/jdbc-clickhouse-sink.md
+++ b/connectors/jdbc-clickhouse-sink/v3.1.2/jdbc-clickhouse-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC clickhouse Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.1/connectors/pulsar-io-jdbc-clickhouse-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-clickhouse-sink/v3.2.3/jdbc-clickhouse-sink.md
+++ b/connectors/jdbc-clickhouse-sink/v3.2.3/jdbc-clickhouse-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC clickhouse Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-jdbc-clickhouse-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-clickhouse-sink/v3.3.1/jdbc-clickhouse-sink.md
+++ b/connectors/jdbc-clickhouse-sink/v3.3.1/jdbc-clickhouse-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC clickhouse Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-jdbc-clickhouse-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/jdbc-mariadb-sink.yaml
+++ b/connectors/jdbc-mariadb-sink/jdbc-mariadb-sink.yaml
@@ -1,1 +1,0 @@
-icon: /images/connectors/apache-logo.png

--- a/connectors/jdbc-mariadb-sink/v2.10.5/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v2.10.5/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-jdbc-mariadb-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/v2.11.4/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v2.11.4/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-jdbc-mariadb-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/v3.0.6/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v3.0.6/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-jdbc-mariadb-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/v3.1.2/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v3.1.2/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-jdbc-mariadb-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/v3.2.3/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v3.2.3/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-jdbc-mariadb-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-mariadb-sink/v3.3.1/jdbc-mariadb-sink.md
+++ b/connectors/jdbc-mariadb-sink/v3.3.1/jdbc-mariadb-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-jdbc-mariadb-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/jdbc-postgres-sink.yaml
+++ b/connectors/jdbc-postgres-sink/jdbc-postgres-sink.yaml
@@ -1,1 +1,0 @@
-icon: /images/connectors/apache-logo.png

--- a/connectors/jdbc-postgres-sink/v2.10.5/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v2.10.5/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-jdbc-sqlite-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/v2.11.4/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v2.11.4/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-jdbc-sqlite-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/v3.0.6/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v3.0.6/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-jdbc-sqlite-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/v3.1.2/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v3.1.2/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-jdbc-sqlite-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/v3.2.3/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v3.2.3/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-jdbc-sqlite-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-postgres-sink/v3.3.1/jdbc-postgres-sink.md
+++ b/connectors/jdbc-postgres-sink/v3.3.1/jdbc-postgres-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-jdbc-sqlite-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/jdbc-sqlite-sink.yaml
+++ b/connectors/jdbc-sqlite-sink/jdbc-sqlite-sink.yaml
@@ -1,1 +1,0 @@
-icon: /images/connectors/apache-logo.png

--- a/connectors/jdbc-sqlite-sink/v2.10.5/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v2.10.5/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.10.5.15/pulsar-io-jdbc-mariadb-2.10.5.15.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/v2.11.4/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v2.11.4/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v2.11.4.3/pulsar-io-jdbc-mariadb-2.11.4.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/v3.0.6/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v3.0.6/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.0.6.1/pulsar-io-jdbc-mariadb-3.0.6.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/v3.1.2/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v3.1.2/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.1.2.3/pulsar-io-jdbc-mariadb-3.1.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/v3.2.3/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v3.2.3/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.2.3.2/pulsar-io-jdbc-mariadb-3.2.3.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/jdbc-sqlite-sink/v3.3.1/jdbc-sqlite-sink.md
+++ b/connectors/jdbc-sqlite-sink/v3.3.1/jdbc-sqlite-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "JDBC", "Sink"]
 alias: JDBC Sink
 features: ["Use JDBC sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: /images/connectors/apache-logo.png
 download: "https://github.com/streamnative/pulsar/releases/download/v3.3.1.2/pulsar-io-jdbc-mariadb-3.3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/netty-source.yaml
+++ b/connectors/netty-source/netty-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/netty.png"

--- a/connectors/netty-source/v2.10.5/netty-source.md
+++ b/connectors/netty-source/v2.10.5/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-netty-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/v2.11.4/netty-source.md
+++ b/connectors/netty-source/v2.11.4/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-netty-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/v3.0.6/netty-source.md
+++ b/connectors/netty-source/v3.0.6/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-netty-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/v3.1.2/netty-source.md
+++ b/connectors/netty-source/v3.1.2/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-netty-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/v3.2.3/netty-source.md
+++ b/connectors/netty-source/v3.2.3/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-netty-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/netty-source/v3.3.1/netty-source.md
+++ b/connectors/netty-source/v3.3.1/netty-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Netty", "Source"]
 alias: Netty Source
 features: ["Use Netty source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/netty.jpg"
+icon: "/images/connectors/netty.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-netty-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/rabbitmq-sink.yaml
+++ b/connectors/rabbitmq-sink/rabbitmq-sink.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/rabbitmq.png"

--- a/connectors/rabbitmq-sink/v2.10.5/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v2.10.5/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-rabbitmq-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/v2.11.4/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v2.11.4/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-rabbitmq-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/v3.0.6/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v3.0.6/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-rabbitmq-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/v3.1.2/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v3.1.2/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-rabbitmq-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/v3.2.3/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v3.2.3/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-rabbitmq-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-sink/v3.3.1/rabbitmq-sink.md
+++ b/connectors/rabbitmq-sink/v3.3.1/rabbitmq-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Sink"]
 alias: RabbitMQ Sink
 features: ["Use RabbitMQ sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-rabbitmq-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/rabbitmq-source.yaml
+++ b/connectors/rabbitmq-source/rabbitmq-source.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/rabbitmq.png"

--- a/connectors/rabbitmq-source/v2.10.5/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v2.10.5/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-rabbitmq-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/v2.11.4/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v2.11.4/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-rabbitmq-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/v3.0.6/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v3.0.6/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-rabbitmq-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/v3.1.2/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v3.1.2/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-rabbitmq-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/v3.2.3/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v3.2.3/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-rabbitmq-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/rabbitmq-source/v3.3.1/rabbitmq-source.md
+++ b/connectors/rabbitmq-source/v3.3.1/rabbitmq-source.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "RabbitMQ", "Source"]
 alias: RabbitMQ source
 features: ["Use RabbitMQ source connector to sync data to Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/connectors/rabbitmq.jpg"
+icon: "/images/connectors/rabbitmq.png"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-rabbitmq-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/solr-sink.yaml
+++ b/connectors/solr-sink/solr-sink.yaml
@@ -1,1 +1,0 @@
-icon: "/images/connectors/solr.jpg"

--- a/connectors/solr-sink/v2.10.5/solr-sink.md
+++ b/connectors/solr-sink/v2.10.5/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.10.5/connectors/pulsar-io-solr-2.10.5.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/v2.11.4/solr-sink.md
+++ b/connectors/solr-sink/v2.11.4/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-2.11.4/connectors/pulsar-io-solr-2.11.4.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/v3.0.6/solr-sink.md
+++ b/connectors/solr-sink/v3.0.6/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.0.6/connectors/pulsar-io-solr-3.0.6.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/v3.1.2/solr-sink.md
+++ b/connectors/solr-sink/v3.1.2/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.1.2/connectors/pulsar-io-solr-3.1.2.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/v3.2.3/solr-sink.md
+++ b/connectors/solr-sink/v3.2.3/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.2.3/connectors/pulsar-io-solr-3.2.3.nar"
 support: StreamNative
 support_link: https://streamnative.io

--- a/connectors/solr-sink/v3.3.1/solr-sink.md
+++ b/connectors/solr-sink/v3.3.1/solr-sink.md
@@ -10,7 +10,7 @@ tags: ["Pulsar IO", "Solr", "Sink"]
 alias: Solr Sink
 features: ["Use Solr sink connector to sync data from Pulsar"]
 license_link: "https://www.apache.org/licenses/LICENSE-2.0"
-icon: "/images/pulsar-hub.svg"
+icon: "/images/connectors/solr.jpg"
 download: "https://archive.apache.org/dist/pulsar/pulsar-3.3.1/connectors/pulsar-io-solr-3.3.1.nar"
 support: StreamNative
 support_link: https://streamnative.io


### PR DESCRIPTION
For manual docs of connectors, don't add *.yaml, otherwise, the auto upgrade version script will not work.


please refer to: https://github.com/streamnative/pulsar-hub/blob/425ec232ea4ffeb2cbfaba1d19dd669ebac69331/auto-upgrade.js#L128-L136